### PR TITLE
Fix the uploader HTTP 503 response

### DIFF
--- a/harvest.py
+++ b/harvest.py
@@ -22,6 +22,8 @@ UPLOAD_COMMENT = 'Importing MBC digital content'
 OAI_SET_NAME = 'MDL:CD:Warwilustrpras'
 
 
+START_FROM_ITEM = 5005
+
 @dataclass
 class RecordMeta:
     """
@@ -243,6 +245,10 @@ def main():
     logger.info('pywikibot: %r', commons)
 
     for idx, record in enumerate(get_set(harvester, OAI_SET_NAME)):
+        if idx < START_FROM_ITEM:
+            logger.info('Skipping record #%d due to START_FROM_ITEM', idx)
+            continue
+
         logger.info('---')
         logger.info('Record #%d found: %r', idx + 1, record)
         # logger.info('Metadata: %r', record.metadata)


### PR DESCRIPTION
Try to solve the following:

```
INFO:oai-harvester:Record #5005 found: <Record oai:mbc.cyfrowemazowsze.pl:52926>
INFO:root:Fetching RDF from <http://mbc.cyfrowemazowsze.pl//dlibra/rdf.xml?type=e&id=52926>
INFO:upload_to_commons:Record metadata: RecordMeta(record_id='oai:mbc.cyfrowemazowsze.pl:52926', source_id='mbc.cyfrowemazowsze.pl', title='Wyścig dystansowy Warszawa - Kalisz - Warszawa : Przed wyścigiem', medium='grafika', date='1895', content_url='http://mbc.cyfrowemazowsze.pl/Content/52926/00057442-0001.jpg', tags=['1801-1900', 'Biesiada Literacka', 'Bogacki, Stanisław', 'Grafika polska - 19 w.', 'Warszawa', 'Warszawa - sport - 19 w.', 'Warszawskie Towarzystwo Cyklistów', 'Wyścigi kolarskie'], creator='', notes='1 grafika ; 9x16,5 cm, z napisami12x16,5 cm', source='Biesiada Literacka. T. 39, 1895 nr 24 s. 381')
INFO:upload_to_commons:File page: FilePage('File:Wyścig dystansowy Warszawa - Kalisz - Warszawa Przed wyścigiem (52926).jpg')
INFO:upload_to_commons:File description: =={{int:filedesc}}==
{{Artwork
 |artist = 
 |description = {{pl|Wyścig dystansowy Warszawa - Kalisz - Warszawa : Przed wyścigiem}}
 |date = 1895
 |medium = {{technique|drawing}}
 |institution = {{Institution:Mazovian Digital Library}}
 |notes = 1 grafika ; 9x16,5 cm, z napisami12x16,5 cm
 |accession number = [http://fbc.pionier.net.pl/id/oai:mbc.cyfrowemazowsze.pl:52926 oai:mbc.cyfrowemazowsze.pl:52926]
 |source = 
* http://mbc.cyfrowemazowsze.pl/dlibra/docmetadata?id=52926
* Biesiada Literacka. T. 39, 1895 nr 24 s. 381
}}

=={{int:license-header}}==
{{PD-old-auto}}
{{Mazovian Digital Library partnership}}

[[Category:Uploaded with mbc-harvester]]
[[Category:Media contributed by the Mazovian Digital Library]]
[[Category:Needing category from the Mazovian Digital Library]]
[[Category:Media contributed by the Mazovian Digital Library – needing category]]
WARNING: API error http-bad-status: There was a problem during the HTTP request: 503 Service Unavailable
ERROR:oai-harvester:Exception
Traceback (most recent call last):
  File "/Users/macbre/git/mbc-importer/harvest.py", line 290, in main
    upload_to_commons(site=commons, record=record_meta)
  File "/Users/macbre/git/mbc-importer/harvest.py", line 227, in upload_to_commons
    return file_page.upload(
  File "/Users/macbre/git/mbc-importer/env/lib/python3.10/site-packages/pywikibot/page/_filepage.py", line 267, in upload
    return self.site.upload(self, source_filename=filename, source_url=url,
  File "/Users/macbre/git/mbc-importer/env/lib/python3.10/site-packages/pywikibot/site/_decorators.py", line 92, in callee
    return fn(self, *args, **kwargs)
  File "/Users/macbre/git/mbc-importer/env/lib/python3.10/site-packages/pywikibot/site/_apisite.py", line 2739, in upload
    return Uploader(self, filepage, **kwargs).upload()
  File "/Users/macbre/git/mbc-importer/env/lib/python3.10/site-packages/pywikibot/site/_upload.py", line 137, in upload
    return self._upload(self.ignore_warnings, self.report_success)
  File "/Users/macbre/git/mbc-importer/env/lib/python3.10/site-packages/pywikibot/site/_upload.py", line 442, in _upload
    return self.submit(final_request, result, data.get('result'),
  File "/Users/macbre/git/mbc-importer/env/lib/python3.10/site-packages/pywikibot/site/_upload.py", line 469, in submit
    raise error
  File "/Users/macbre/git/mbc-importer/env/lib/python3.10/site-packages/pywikibot/site/_upload.py", line 463, in submit
    result = request.submit()
  File "/Users/macbre/git/mbc-importer/env/lib/python3.10/site-packages/pywikibot/data/api/_requests.py", line 1108, in submit
    raise pywikibot.exceptions.APIError(**error)
pywikibot.exceptions.APIError: http-bad-status: There was a problem during the HTTP request: 503 Service Unavailable
[servedby: mw1444;
 help: See https://commons.wikimedia.org/w/api.php for API usage. Subscribe to the mediawiki-api-announce mailing list at &lt;https://lists.wikimedia.org/postorius/lists/mediawiki-api-announce.lists.wikimedia.org/&gt; for notice of API deprecations and breaking changes.]
INFO:oai-harvester:---
```